### PR TITLE
Add single use install command

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -90,7 +90,7 @@ fn validate_no_conflicting_files(lock: &Lock) -> Result<(), LockError> {
     Ok(())
 }
 
-fn parse_package(path: &PathBuf, name: String) -> Vec<FileLock> {
+pub(crate) fn parse_package(path: &PathBuf, name: String) -> Vec<FileLock> {
     let config = ProjectConfig::load(path.join("Smaug.toml"));
     debug!("PackageConfig: {:?}", config);
     let mut files: Vec<FileLock> = vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> io::Result<()> {
         (@subcommand install =>
             (about: "Installs dependencies from Smaug.toml.")
             (@arg PATH: "The path to your project. Defaults to the current directory.")
+            (@arg PACKAGE: "The location of a package to install. If not provided, will install from Smaug.toml.")
         )
     )
     .get_matches();

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -147,7 +147,7 @@ fn load_dependency((name, value): (&String, &Value)) -> Dependency {
     }
 }
 
-fn load_dependency_string(name: &str, value: &str) -> Dependency {
+pub fn load_dependency_string(name: &str, value: &str) -> Dependency {
     let path = Path::new(value);
     let mut dir: Option<String> = None;
     let mut repo: Option<String> = None;


### PR DESCRIPTION
`smaug install https://github.com/guitsaru/draco.git`

The purpose of this command is to provide an easy method to install single use artifacts.

Examples:
* Sprites
* Music
* Draco starter systems and components that are meant to be editable