### PR TITLE
Hardcode DR version requirements for packages.

### DIFF
--- a/cli/templates/Package.toml.template
+++ b/cli/templates/Package.toml.template
@@ -13,5 +13,5 @@ url = "TODO: Package Website"
 # "lib/library.rb" = "app/lib/library.rb"
 
 [dragonruby]
-version = "{ version }"
-edition = "{ edition }"
+version = "2"
+edition = "standard"


### PR DESCRIPTION
Sets the package DragonRuby version to "2" and "standard". This allows for the most matching versions.

Fixes #22