### PR TITLE
Respect `.smaugignore` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version 0.3.1
 
 * Add `config` command to show your current Smaug configuration
+* Respect `.smaugignore` file when building projects or installing packages
+
 # Version 0.3.0
 
 * Add `--json` argument to all commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +616,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1310,6 +1350,7 @@ dependencies = [
  "derive_more",
  "directories",
  "git2",
+ "ignore",
  "linked-hash-map",
  "log",
  "regex",

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -78,6 +78,7 @@ impl Command for Build {
                 let build_dir = bin_dir.join(path.file_name().unwrap());
 
                 copy_directory(&path, &build_dir).expect("Could not copy to build directory.");
+                debug!("Build Directory: {:?}", build_dir);
 
                 let log_dir = build_dir.join("logs");
                 let exception_dir = build_dir.join("exceptions");

--- a/smaug/Cargo.toml
+++ b/smaug/Cargo.toml
@@ -11,6 +11,7 @@ blake2 = "0.9"
 derive_more = "0.99.11"
 directories = "3.0.1"
 git2 = "0.13"
+ignore = "0.4.17"
 linked-hash-map = { version = "0.5.4", features = ["serde_impl"] }
 log = "0.4"
 regex = "1"

--- a/smaug/src/config.rs
+++ b/smaug/src/config.rs
@@ -172,9 +172,9 @@ impl<'de> Deserialize<'de> for DependencyOptions {
                         tag: None,
                     })
                 } else if path.is_dir() {
-                    Ok(DependencyOptions::Dir {
-                        dir: path.to_path_buf(),
-                    })
+                    let canonical =
+                        std::fs::canonicalize(path.clone()).expect("Could not find path.");
+                    Ok(DependencyOptions::Dir { dir: canonical })
                 } else if path.is_file() {
                     Ok(DependencyOptions::File {
                         file: path.to_path_buf(),

--- a/smaug/src/lib.rs
+++ b/smaug/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate derive_more;
+extern crate ignore;
 extern crate regex;
 extern crate semver;
 extern crate shellexpand;

--- a/smaug/src/util/dir.rs
+++ b/smaug/src/util/dir.rs
@@ -1,3 +1,4 @@
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use log::*;
 use std::fs;
 use std::io;
@@ -5,13 +6,24 @@ use std::path::Path;
 use walkdir::WalkDir;
 
 pub fn copy_directory<P: AsRef<Path>>(source: &P, destination: &P) -> io::Result<()> {
+    let mut ignore_builder = GitignoreBuilder::new(source);
+    let ignore_file = source.as_ref().join(".smaugignore");
+
+    if ignore_file.is_file() {
+        ignore_builder.add(ignore_file);
+    }
+
+    let ignore = ignore_builder
+        .build()
+        .expect("Could not parse smaugignore file");
+
     for entry in WalkDir::new(source) {
         let entry = entry.expect("Could not find directory");
         let entry = entry.path();
         let relative = entry.strip_prefix(source.as_ref()).unwrap();
         let new_path = destination.as_ref().join(relative);
 
-        if entry.is_file() && !is_git_dir(entry.to_str().unwrap()) {
+        if entry.is_file() && !is_ignored(entry, &ignore) {
             trace!(
                 "Creating directory {}",
                 new_path.parent().and_then(|p| p.to_str()).unwrap()
@@ -31,4 +43,20 @@ pub fn copy_directory<P: AsRef<Path>>(source: &P, destination: &P) -> io::Result
 
 fn is_git_dir(path: &str) -> bool {
     path.contains("/.git/") || path.contains("\\.git\\")
+}
+
+fn is_ignored(path: &Path, ignore: &Gitignore) -> bool {
+    if matches_ignore(path, ignore) {
+        trace!("Ignoring {:?}", path);
+        return true;
+    }
+
+    false
+}
+
+fn matches_ignore(path: &Path, ignore: &Gitignore) -> bool {
+    ignore
+        .matched_path_or_any_parents(path, path.is_dir())
+        .is_ignore()
+        || is_git_dir(path.to_string_lossy().as_ref())
 }


### PR DESCRIPTION
Respects `.smaugignore` file when installing packages or building projects. `.smaugignore` uses the same format as `.gitignore`.

Fixes #31 