### PR TITLE
Use a unique name for the package source file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,18 +1,18 @@
 # Maintainer: Logan Koester <logan@logankoester.com>
 pkgname=smaug
 pkgver=0.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A tool to manage your DragonRuby Game Toolkit projects"
 arch=('x86_64')
 url="https://smaug.dev/"
 license=('AGPL3')
 depends=(gcc-libs openssl zlib)
 optdepends=()
-source=("https://github.com/ereborstudios/smaug/releases/download/v${pkgver}/smaug-linux")
+source=("$pkgname-$pkgver::https://github.com/ereborstudios/smaug/releases/download/v${pkgver}/smaug-linux")
 noextract=()
 sha512sums=('bef026f26ef1680d1ceeabe0b2f0d3855d5978d7a14e6a8a99784efa5a44f412ef167071813150bcd4dd1a88563b1cd870f8A6D7308143BEC7DA8560556fd744')
 
 package() {
   cd $srcdir
-  install -Dm755 "${pkgname}-linux" "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm755 "${pkgname}-${pkgver}" "${pkgdir}/usr/bin/${pkgname}"
 }


### PR DESCRIPTION
Previously, the AUR package would download the source file named `smaug-linux`, then install it. However, this source file continues to exist in the local package cache, which causes the next upgrade to fail. The problem is that the next version of this file won't be downloaded, because a file of the same name already exists locally - but of course that file fails the checksum for the version that we're trying to install.

To resolve this conflict, the source file has been renamed to include the version number matching the expected checksum.