### PR TITLE
Remove "TODO:" from default authors value - colon prevents Windows builds from starting

### DIFF
--- a/cli/templates/Project.toml.template
+++ b/cli/templates/Project.toml.template
@@ -4,7 +4,7 @@ name = "{ name }"
 # The game's title. This will show up in the tile bar of your executable.
 title = "{ name }"
 version = "0.1.0"
-authors = ["TODO: My Name <todo@example.com>"]
+authors = ["My Name <todo@example.com>"]
 icon = "metadata/icon.png"
 compile_ruby = false
 


### PR DESCRIPTION
What it says on the tin 👍 🥳 