### PR TITLE
switch canonicalize from std to dunce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1366,7 @@ version = "0.5.1"
 dependencies = [
  "clap",
  "derive_more",
+ "dunce",
  "log",
  "open",
  "question",
@@ -1383,6 +1390,7 @@ dependencies = [
  "blake2",
  "derive_more",
  "directories",
+ "dunce",
  "git2",
  "ignore",
  "linked-hash-map",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ smaug-lib = { path = "../smaug", version = "0.5.1" }
 
 clap = "3.0.0-beta.2"
 derive_more = "0.99.11"
+dunce = "*"
 log = "0.4"
 open = "1.7.0"
 question = "0.2.2"

--- a/cli/src/commands/add.rs
+++ b/cli/src/commands/add.rs
@@ -11,6 +11,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use toml_edit::{value, Document};
+use dunce;
 
 pub struct Add;
 
@@ -44,7 +45,7 @@ impl Command for Add {
 
         debug!("Directory: {}", directory);
 
-        let canonical = match std::fs::canonicalize(directory) {
+        let canonical = match dunce::canonicalize(directory) {
             Ok(dir) => dir,
             Err(..) => {
                 return Err(Box::new(Error::FileNotFound {
@@ -54,7 +55,7 @@ impl Command for Add {
         };
 
         let path = Path::new(&canonical);
-        let path = std::fs::canonicalize(&path).expect("Could not find path");
+        let path = dunce::canonicalize(&path).expect("Could not find path");
 
         let config_path = path.join("Smaug.toml");
 

--- a/cli/src/commands/bind.rs
+++ b/cli/src/commands/bind.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process;
+use dunce;
 
 #[derive(Debug, Display, Serialize)]
 #[display(fmt = "Succesfully created bindings.")]
@@ -46,7 +47,7 @@ impl Command for Bind {
             .value_of("path")
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
-        let path = match std::fs::canonicalize(directory) {
+        let path = match dunce::canonicalize(directory) {
             Ok(dir) => dir,
             Err(..) => {
                 return Err(Box::new(Error::FileNotFound {

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -11,6 +11,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process;
+use dunce;
 
 #[derive(Debug)]
 pub struct Build;
@@ -48,7 +49,7 @@ impl Command for Build {
             .value_of("path")
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
-        let path = match std::fs::canonicalize(directory) {
+        let path = match dunce::canonicalize(directory) {
             Ok(dir) => dir,
             Err(..) => {
                 return Err(Box::new(Error::FileNotFound {

--- a/cli/src/commands/docs.rs
+++ b/cli/src/commands/docs.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use smaug_lib::dragonruby;
 use std::env;
 use std::path::Path;
+use dunce;
 
 #[derive(Debug, Serialize, Display)]
 #[display(fmt = "Opened docs in your web browser.")]
@@ -33,7 +34,7 @@ impl Command for Docs {
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
         let path = Path::new(directory);
-        let path = std::fs::canonicalize(&path).expect("Could not find path");
+        let path = dunce::canonicalize(&path).expect("Could not find path");
 
         let config_path = path.join("Smaug.toml");
 

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -12,6 +12,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use tinytemplate::TinyTemplate;
+use dunce;
 
 #[derive(Debug)]
 pub struct Install;
@@ -41,7 +42,7 @@ impl Command for Install {
             .value_of("path")
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
-        let canonical = match std::fs::canonicalize(directory) {
+        let canonical = match dunce::canonicalize(directory) {
             Ok(dir) => dir,
             Err(..) => {
                 return Err(Box::new(Error::FileNotFound {
@@ -50,7 +51,7 @@ impl Command for Install {
             }
         };
         let path = Path::new(&canonical);
-        let path = std::fs::canonicalize(&path).expect("Could not find path");
+        let path = dunce::canonicalize(&path).expect("Could not find path");
 
         let config_path = path.join("Smaug.toml");
 

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -11,6 +11,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process;
+use dunce;
 
 #[derive(Debug)]
 pub struct Publish;
@@ -48,7 +49,7 @@ impl Command for Publish {
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
         let path = Path::new(directory);
-        let path = std::fs::canonicalize(&path).expect("Could not find path");
+        let path = dunce::canonicalize(&path).expect("Could not find path");
 
         let config_path = path.join("Smaug.toml");
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::process;
 use std::fs::{File, create_dir};
 use std::io::prelude::*;
+use dunce;
 
 #[derive(Debug)]
 pub struct Run;
@@ -55,7 +56,8 @@ impl Command for Run {
             .unwrap_or_else(|| current_directory.to_str().unwrap());
         debug!("Directory: {}", directory);
         let path = Path::new(directory);
-        let path = std::fs::canonicalize(&path).expect("Could not find path");
+        let path = dunce::canonicalize(&path).expect("Could not find path");
+        debug!("path: {:?}", path);
 
         let config_path = path.join("Smaug.toml");
 
@@ -68,7 +70,7 @@ impl Command for Run {
         let metadata_file = path.join("metadata").join("game_metadata.txt");
         debug!("{:?}", metadata_file);
         let metadata_file =
-            std::fs::canonicalize(&metadata_file).expect("Could not create canonical path");
+            dunce::canonicalize(&metadata_file).expect("Could not create canonical path");
         trace!("Writing game metadata to {}.", metadata_file.display());
         let metadata = game_metadata::from_config(&config);
         metadata

--- a/smaug/Cargo.toml
+++ b/smaug/Cargo.toml
@@ -18,6 +18,7 @@ name = "smaug_lib"
 blake2 = "0.9"
 derive_more = "0.99.11"
 directories = "3.0.1"
+dunce = "*"
 git2 = "0.13"
 ignore = "0.4.17"
 linked-hash-map = { version = "0.5.4", features = ["serde_impl"] }

--- a/smaug/src/config.rs
+++ b/smaug/src/config.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
+use dunce;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -104,7 +105,7 @@ pub enum Error {
 }
 
 pub fn load<P: AsRef<Path>>(path: &P) -> Result<Config, Error> {
-    let canonical = std::fs::canonicalize(path.as_ref());
+    let canonical = dunce::canonicalize(path.as_ref());
     if canonical.is_err() {
         return Err(Error::FileNotFound {
             path: path.as_ref().to_path_buf(),
@@ -173,7 +174,7 @@ impl<'de> Deserialize<'de> for DependencyOptions {
                     })
                 } else if path.is_dir() {
                     let canonical =
-                        std::fs::canonicalize(path.clone()).expect("Could not find path.");
+                        dunce::canonicalize(path.clone()).expect("Could not find path.");
                     Ok(DependencyOptions::Dir { dir: canonical })
                 } else if path.is_file() {
                     Ok(DependencyOptions::File {


### PR DESCRIPTION
Use of the canonicalize func in the std is resulting in a path format that isn't supported by all Windows apps. This may be the case with DragonRuby as well as Smaug isn't able to launch DragonRuby apps with `smaug run`. Switching to canonicalize found in the *dunce* crate fixes this.

https://lib.rs/crates/dunce